### PR TITLE
fixing column width logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.idea/
+.vscode/
 .directory
+vendor/

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/dustin/go-humanize v1.0.1
-	github.com/mattn/go-runewidth v0.0.14
+	github.com/mattn/go-runewidth v0.0.16
 )
 
-require github.com/rivo/uniseg v0.2.0 // indirect
+require github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,9 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/table.go
+++ b/table.go
@@ -972,10 +972,9 @@ func (t *Table) checkWidths() error {
 	}
 
 	for i, c := range t.columns {
-		if c.MaxWidth > 0 && c.MaxWidth < t.maxWidths[i] { // use user defined threshold
+		if c.MaxWidth > 0 { // use user defined column threshold
 			t.maxWidths[i] = c.MaxWidth
-		}
-		if t.maxWidth > 0 && t.maxWidth < t.maxWidths[i] { // use user defined global threshold
+		} else if t.maxWidth > 0 { // use user defined global threshold
 			t.maxWidths[i] = t.maxWidth
 		}
 
@@ -983,10 +982,9 @@ func (t *Table) checkWidths() error {
 			t.maxWidths[i] = 1
 		}
 
-		if c.MinWidth > 0 && c.MinWidth > t.minWidths[i] { // use user defined threshold
+		if c.MinWidth > 0 { // use user defined column threshold
 			t.minWidths[i] = c.MinWidth
-		}
-		if t.minWidth > 0 { // use user defined global threshold
+		} else if t.minWidth > 0 { // use user defined global threshold
 			t.minWidths[i] = t.minWidth
 		}
 	}


### PR DESCRIPTION
The current implementation ignores the manually-defined column widths under several circumstances.

If a user goes through the effort of specifically setting min and max width values for a particular column, those should be used above all else.

It is only when a more granular width setting is not provided that the global / auto-detect values should be used.